### PR TITLE
feat: 邀请制注册系统 + 多项修复优化

### DIFF
--- a/.github/workflows/deploy-aliyun-ssh.yml
+++ b/.github/workflows/deploy-aliyun-ssh.yml
@@ -65,7 +65,12 @@ jobs:
         # 如果你只想同步构建输出（如 dist/），把 SRC 设置为 ./dist/
         SRC=./
         echo "Syncing $SRC -> ${SERVER_USER}@${SERVER_HOST}:${TARGET_DIR}"
-        rsync -avz --delete -e "ssh -p ${SERVER_PORT:-22}" $SRC ${SERVER_USER}@${SERVER_HOST}:${TARGET_DIR}
+        # --exclude 避免覆盖服务器上已有的上传文件
+        rsync -avz --delete \
+          --exclude 'public/uploads/' \
+          --exclude 'node_modules/' \
+          -e "ssh -p ${SERVER_PORT:-22}" \
+          $SRC ${SERVER_USER}@${SERVER_HOST}:${TARGET_DIR}
 
     - name: Run remote commands (restart service)
       env:
@@ -73,9 +78,20 @@ jobs:
         SERVER_USER: ${{ secrets.SERVER_USER }}
         SERVER_HOST: ${{ secrets.SERVER_HOST }}
         SERVER_PORT: ${{ secrets.SERVER_PORT }}
+        UPLOADS_DIR: /var/www/zqzx-uploads
       run: |
         ssh -p ${SERVER_PORT:-22} ${SERVER_USER}@${SERVER_HOST} "bash -s" << EOF
         set -e
         cd ${TARGET_DIR}
-        pm2 restart server.js || pm2 start server.js
+        
+        # 确保上传目录存在
+        mkdir -p ${UPLOADS_DIR}
+        
+        # 安装依赖
+        npm install --production
+        
+        # 使用 ecosystem.config.js 启动，带生产环境变量
+        pm2 restart ecosystem.config.js --env production || pm2 start ecosystem.config.js --env production
+        
+        pm2 save
         EOF

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,0 +1,20 @@
+module.exports = {
+    apps: [{
+        name: 'zqzx-memory',
+        script: 'server.js',
+        instances: 1,
+        autorestart: true,
+        watch: false,
+        max_memory_restart: '500M',
+        env: {
+            NODE_ENV: 'development',
+            PORT: 3000
+        },
+        env_production: {
+            NODE_ENV: 'production',
+            PORT: 3000,
+            // 如果需要自定义上传目录，取消下面这行的注释
+            // UPLOADS_DIR: '/var/www/zqzx-uploads'
+        }
+    }]
+};

--- a/migrations/001_auth_tables.sql
+++ b/migrations/001_auth_tables.sql
@@ -42,3 +42,16 @@ ALTER TABLE comments ADD FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SE
 -- 初始邀请码（可由管理员在数据库中手动添加）
 -- 示例：INSERT INTO invite_codes (code) VALUES ('ZQZX2025ADMIN01');
 -- =====================================================
+
+-- 举报表
+CREATE TABLE IF NOT EXISTS reports (
+    id INT PRIMARY KEY AUTO_INCREMENT,
+    post_id INT NOT NULL,
+    reporter_id INT,
+    reason VARCHAR(255),
+    status ENUM('pending', 'resolved', 'dismissed') DEFAULT 'pending',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    resolved_at TIMESTAMP NULL,
+    FOREIGN KEY (post_id) REFERENCES posts(id) ON DELETE CASCADE,
+    FOREIGN KEY (reporter_id) REFERENCES users(id) ON DELETE SET NULL
+);

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -8,6 +8,40 @@
     <link href="https://cdn.bootcdn.net/ajax/libs/twitter-bootstrap/5.3.1/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdn.bootcdn.net/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
     <link rel="stylesheet" href="/css/style.css">
+    <style>
+        .admin-card {
+            border-left: 4px solid;
+            transition: transform 0.2s;
+        }
+
+        .admin-card:hover {
+            transform: translateX(5px);
+        }
+
+        .admin-card.invite {
+            border-color: #ffc107;
+        }
+
+        .admin-card.class {
+            border-color: #198754;
+        }
+
+        .admin-card.report {
+            border-color: #dc3545;
+        }
+
+        .tab-content {
+            padding-top: 20px;
+        }
+
+        .report-preview {
+            background: #f8f9fa;
+            border-radius: 8px;
+            padding: 10px;
+            margin: 10px 0;
+            font-size: 0.9rem;
+        }
+    </style>
 </head>
 
 <body class="app-page">
@@ -15,11 +49,11 @@
         <div class="container d-flex justify-content-between align-items-center">
             <a href="/hall" class="btn btn-sm btn-outline-success"><i class="fas fa-arrow-left"></i> 返回大厅</a>
             <span class="fw-bold fs-5 text-danger">🔒 管理面板</span>
-            <span></span>
+            <span class="badge bg-danger">管理员</span>
         </div>
     </nav>
 
-    <div class="container" style="margin-top: 80px; max-width: 800px;">
+    <div class="container" style="padding-top: 80px; max-width: 900px;">
         <% if (!user || !user.is_admin) { %>
             <div class="alert alert-danger text-center">
                 <i class="fas fa-ban fa-2x mb-2"></i>
@@ -28,83 +62,289 @@
                 <a href="/hall" class="btn btn-outline-danger">返回大厅</a>
             </div>
             <% } else { %>
-                <div class="glass-card p-4 mb-4">
-                    <h4 class="fw-bold mb-4"><i class="fas fa-key text-warning me-2"></i>生成邀请码</h4>
-                    <p class="text-muted">生成系统邀请码供新用户注册使用。这些邀请码不属于任何用户。</p>
+                <!-- 标签页导航 -->
+                <ul class="nav nav-tabs" id="adminTabs" role="tablist">
+                    <li class="nav-item" role="presentation">
+                        <button class="nav-link active" id="invite-tab" data-bs-toggle="tab" data-bs-target="#invite"
+                            type="button">
+                            <i class="fas fa-key text-warning me-1"></i> 邀请码管理
+                        </button>
+                    </li>
+                    <li class="nav-item" role="presentation">
+                        <button class="nav-link" id="class-tab" data-bs-toggle="tab" data-bs-target="#class"
+                            type="button">
+                            <i class="fas fa-school text-success me-1"></i> 班级管理
+                        </button>
+                    </li>
+                    <li class="nav-item" role="presentation">
+                        <button class="nav-link" id="report-tab" data-bs-toggle="tab" data-bs-target="#report"
+                            type="button">
+                            <i class="fas fa-flag text-danger me-1"></i> 举报处理
+                            <% if (typeof reports !=='undefined' && reports.filter(r=> r.status === 'pending').length >
+                                0) { %>
+                                <span class="badge bg-danger">
+                                    <%= reports.filter(r=> r.status === 'pending').length %>
+                                </span>
+                                <% } %>
+                        </button>
+                    </li>
+                </ul>
 
-                    <form action="/admin/generate-code" method="POST" class="row g-3 align-items-center">
-                        <div class="col-auto">
-                            <label class="form-label mb-0">生成数量：</label>
-                        </div>
-                        <div class="col-auto">
-                            <select name="count" class="form-select">
-                                <option value="1">1个</option>
-                                <option value="3">3个</option>
-                                <option value="5">5个</option>
-                                <option value="10">10个</option>
-                            </select>
-                        </div>
-                        <div class="col-auto">
-                            <button type="submit" class="btn btn-warning">
-                                <i class="fas fa-plus me-1"></i> 生成邀请码
-                            </button>
-                        </div>
-                    </form>
+                <div class="tab-content" id="adminTabContent">
+                    <!-- 邀请码管理 -->
+                    <div class="tab-pane fade show active" id="invite" role="tabpanel">
+                        <div class="glass-card p-4 mb-4 admin-card invite">
+                            <h5 class="fw-bold mb-3"><i class="fas fa-plus-circle text-warning me-2"></i>生成系统邀请码</h5>
+                            <form action="/admin/generate-code" method="POST" class="row g-3 align-items-center">
+                                <div class="col-auto">
+                                    <label class="form-label mb-0">生成数量：</label>
+                                </div>
+                                <div class="col-auto">
+                                    <select name="count" class="form-select">
+                                        <option value="1">1个</option>
+                                        <option value="3">3个</option>
+                                        <option value="5">5个</option>
+                                        <option value="10">10个</option>
+                                    </select>
+                                </div>
+                                <div class="col-auto">
+                                    <button type="submit" class="btn btn-warning">
+                                        <i class="fas fa-magic me-1"></i> 生成
+                                    </button>
+                                </div>
+                            </form>
 
-                    <% if (typeof newCodes !=='undefined' && newCodes && newCodes.length> 0) { %>
-                        <div class="alert alert-success mt-4">
-                            <strong>✅ 生成成功！新邀请码：</strong>
-                            <ul class="mb-0 mt-2">
-                                <% newCodes.forEach(code=> { %>
-                                    <li><code class="fs-5"><%= code %></code></li>
-                                    <% }) %>
-                            </ul>
-                        </div>
-                        <% } %>
-                </div>
-
-                <div class="glass-card p-4">
-                    <h5 class="fw-bold mb-3"><i class="fas fa-list text-info me-2"></i>系统邀请码列表</h5>
-
-                    <% if (systemCodes.length===0) { %>
-                        <p class="text-muted text-center">暂无系统邀请码</p>
-                        <% } else { %>
-                            <div class="table-responsive">
-                                <table class="table table-hover">
-                                    <thead>
-                                        <tr>
-                                            <th>邀请码</th>
-                                            <th>状态</th>
-                                            <th>使用者</th>
-                                            <th>创建时间</th>
-                                        </tr>
-                                    </thead>
-                                    <tbody>
-                                        <% systemCodes.forEach(code=> { %>
-                                            <tr class="<%= code.used_by ? 'table-secondary' : '' %>">
-                                                <td><code><%= code.code %></code></td>
-                                                <td>
-                                                    <% if (code.used_by) { %>
-                                                        <span class="badge bg-secondary">已使用</span>
-                                                        <% } else { %>
-                                                            <span class="badge bg-success">可用</span>
-                                                            <% } %>
-                                                </td>
-                                                <td>
-                                                    <%= code.used_by ? code.used_by : '-' %>
-                                                </td>
-                                                <td>
-                                                    <%= new Date(code.created_at).toLocaleString('zh-CN') %>
-                                                </td>
-                                            </tr>
+                            <% if (typeof newCodes !=='undefined' && newCodes && newCodes.length> 0) { %>
+                                <div class="alert alert-success mt-4 mb-0">
+                                    <strong>✅ 生成成功！</strong>
+                                    <div class="mt-2">
+                                        <% newCodes.forEach(code=> { %>
+                                            <code class="d-block fs-5 mb-1"><%= code %></code>
                                             <% }) %>
-                                    </tbody>
-                                </table>
+                                    </div>
+                                </div>
+                                <% } %>
+                        </div>
+
+                        <div class="glass-card p-4">
+                            <h5 class="fw-bold mb-3"><i class="fas fa-list text-info me-2"></i>系统邀请码列表</h5>
+                            <% if (systemCodes.length===0) { %>
+                                <p class="text-muted text-center mb-0">暂无系统邀请码</p>
+                                <% } else { %>
+                                    <div class="table-responsive">
+                                        <table class="table table-hover table-sm">
+                                            <thead>
+                                                <tr>
+                                                    <th>邀请码</th>
+                                                    <th>状态</th>
+                                                    <th>使用者</th>
+                                                    <th>创建时间</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                <% systemCodes.forEach(code=> { %>
+                                                    <tr class="<%= code.used_by ? 'table-secondary' : '' %>">
+                                                        <td><code><%= code.code %></code></td>
+                                                        <td>
+                                                            <span
+                                                                class="badge <%= code.used_by ? 'bg-secondary' : 'bg-success' %>">
+                                                                <%= code.used_by ? '已使用' : '可用' %>
+                                                            </span>
+                                                        </td>
+                                                        <td>
+                                                            <%= code.used_by_username || '-' %>
+                                                        </td>
+                                                        <td>
+                                                            <%= new Date(code.created_at).toLocaleDateString('zh-CN') %>
+                                                        </td>
+                                                    </tr>
+                                                    <% }) %>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                    <% } %>
+                        </div>
+                    </div>
+
+                    <!-- 班级管理 -->
+                    <div class="tab-pane fade" id="class" role="tabpanel">
+                        <div class="glass-card p-4 mb-4 admin-card class">
+                            <h5 class="fw-bold mb-3"><i class="fas fa-plus-circle text-success me-2"></i>创建新班级</h5>
+                            <form action="/admin/create-class" method="POST" class="row g-3 align-items-end">
+                                <div class="col-auto">
+                                    <label class="form-label">届</label>
+                                    <select name="year" class="form-select">
+                                        <option value="2025" selected>2025届</option>
+                                        <option value="2024">2024届</option>
+                                        <option value="2026">2026届</option>
+                                    </select>
+                                </div>
+                                <div class="col">
+                                    <label class="form-label">班级名称</label>
+                                    <input type="text" name="className" class="form-control" placeholder="如：高三(15)班"
+                                        required>
+                                </div>
+                                <div class="col-auto">
+                                    <button type="submit" class="btn btn-success">
+                                        <i class="fas fa-plus me-1"></i> 创建班级
+                                    </button>
+                                </div>
+                            </form>
+                        </div>
+
+                        <div class="glass-card p-4">
+                            <h5 class="fw-bold mb-3"><i class="fas fa-school text-info me-2"></i>班级列表</h5>
+                            <% if (typeof classes !=='undefined' && classes.length> 0) { %>
+                                <div class="table-responsive">
+                                    <table class="table table-hover table-sm">
+                                        <thead>
+                                            <tr>
+                                                <th>ID</th>
+                                                <th>班级名称</th>
+                                                <th>帖子数</th>
+                                                <th>创建时间</th>
+                                                <th>操作</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            <% classes.forEach(cls=> { %>
+                                                <tr>
+                                                    <td>
+                                                        <%= cls.id %>
+                                                    </td>
+                                                    <td>
+                                                        <%= cls.full_name %>
+                                                    </td>
+                                                    <td>
+                                                        <%= cls.post_count || 0 %>
+                                                    </td>
+                                                    <td>
+                                                        <%= new Date(cls.created_at).toLocaleDateString('zh-CN') %>
+                                                    </td>
+                                                    <td>
+                                                        <a href="/class/<%= cls.id %>"
+                                                            class="btn btn-sm btn-outline-primary">
+                                                            <i class="fas fa-eye"></i>
+                                                        </a>
+                                                        <form action="/admin/delete-class/<%= cls.id %>" method="POST"
+                                                            class="d-inline"
+                                                            onsubmit="return confirm('确定要删除该班级吗？此操作不可恢复！')">
+                                                            <button type="submit" class="btn btn-sm btn-outline-danger">
+                                                                <i class="fas fa-trash"></i>
+                                                            </button>
+                                                        </form>
+                                                    </td>
+                                                </tr>
+                                                <% }) %>
+                                        </tbody>
+                                    </table>
+                                </div>
+                                <% } else { %>
+                                    <p class="text-muted text-center mb-0">暂无班级</p>
+                                    <% } %>
+                        </div>
+                    </div>
+
+                    <!-- 举报处理 -->
+                    <div class="tab-pane fade" id="report" role="tabpanel">
+                        <div class="glass-card p-4 admin-card report">
+                            <h5 class="fw-bold mb-3"><i class="fas fa-flag text-danger me-2"></i>待处理举报</h5>
+
+                            <% if (typeof reports==='undefined' || reports.filter(r=> r.status === 'pending').length ===
+                                0) { %>
+                                <div class="text-center text-muted py-4">
+                                    <i class="fas fa-check-circle fa-3x text-success mb-3"></i>
+                                    <p>暂无待处理的举报</p>
+                                </div>
+                                <% } else { %>
+                                    <% reports.filter(r=> r.status === 'pending').forEach(report => { %>
+                                        <div class="card mb-3">
+                                            <div class="card-body">
+                                                <div class="d-flex justify-content-between align-items-start mb-2">
+                                                    <div>
+                                                        <span class="badge bg-warning text-dark">待处理</span>
+                                                        <small class="text-muted ms-2">
+                                                            <%= new Date(report.created_at).toLocaleString('zh-CN') %>
+                                                        </small>
+                                                    </div>
+                                                    <small class="text-muted">举报人: <%= report.reporter_name || '匿名' %>
+                                                            </small>
+                                                </div>
+
+                                                <div class="report-preview">
+                                                    <strong>被举报帖子内容：</strong>
+                                                    <p class="mb-0 mt-1">
+                                                        <%= report.post_content ? report.post_content.substring(0, 200)
+                                                            + (report.post_content.length> 200 ? '...' : '') : '帖子已删除'
+                                                            %>
+                                                    </p>
+                                                </div>
+
+                                                <div class="d-flex gap-2 mt-3">
+                                                    <a href="/class/<%= report.class_id %>"
+                                                        class="btn btn-sm btn-outline-primary" target="_blank">
+                                                        <i class="fas fa-eye me-1"></i>查看帖子
+                                                    </a>
+                                                    <form action="/admin/report/<%= report.id %>/delete-post"
+                                                        method="POST" class="d-inline">
+                                                        <button type="submit" class="btn btn-sm btn-danger"
+                                                            onclick="return confirm('确定删除该帖子吗？')">
+                                                            <i class="fas fa-trash me-1"></i>删除帖子
+                                                        </button>
+                                                    </form>
+                                                    <form action="/admin/report/<%= report.id %>/dismiss" method="POST"
+                                                        class="d-inline">
+                                                        <button type="submit" class="btn btn-sm btn-secondary">
+                                                            <i class="fas fa-times me-1"></i>驳回举报
+                                                        </button>
+                                                    </form>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <% }) %>
+                                            <% } %>
+                        </div>
+
+                        <% if (typeof reports !=='undefined' && reports.filter(r=> r.status !== 'pending').length > 0) {
+                            %>
+                            <div class="glass-card p-4 mt-4">
+                                <h6 class="text-muted mb-3">历史记录</h6>
+                                <div class="table-responsive">
+                                    <table class="table table-sm small">
+                                        <thead>
+                                            <tr>
+                                                <th>时间</th>
+                                                <th>状态</th>
+                                                <th>帖子ID</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            <% reports.filter(r=> r.status !== 'pending').slice(0, 10).forEach(r => { %>
+                                                <tr>
+                                                    <td>
+                                                        <%= new Date(r.created_at).toLocaleDateString('zh-CN') %>
+                                                    </td>
+                                                    <td>
+                                                        <span
+                                                            class="badge <%= r.status === 'resolved' ? 'bg-success' : 'bg-secondary' %>">
+                                                            <%= r.status==='resolved' ? '已处理' : '已驳回' %>
+                                                        </span>
+                                                    </td>
+                                                    <td>#<%= r.post_id %>
+                                                    </td>
+                                                </tr>
+                                                <% }) %>
+                                        </tbody>
+                                    </table>
+                                </div>
                             </div>
                             <% } %>
+                    </div>
                 </div>
                 <% } %>
     </div>
+
+    <script src="https://cdn.bootcdn.net/ajax/libs/twitter-bootstrap/5.3.1/js/bootstrap.bundle.min.js"></script>
 </body>
 
 </html>

--- a/views/class.ejs
+++ b/views/class.ejs
@@ -10,6 +10,53 @@
     <link href="https://cdn.bootcdn.net/ajax/libs/twitter-bootstrap/5.3.1/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdn.bootcdn.net/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
     <link rel="stylesheet" href="/css/style.css">
+    <style>
+        /* 修复顶部导航遮挡问题 */
+        body {
+            padding-top: 70px;
+        }
+
+        .glass-nav {
+            height: 60px;
+            z-index: 1030;
+        }
+
+        /* 发帖区域样式优化 */
+        .post-form-card {
+            position: sticky;
+            top: 80px;
+            z-index: 10;
+        }
+
+        /* 匿名ID样式 */
+        .anon-id {
+            display: inline-block;
+            padding: 2px 8px;
+            border-radius: 12px;
+            font-size: 0.75rem;
+            font-weight: 600;
+        }
+
+        .anon-id-poster {
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+        }
+
+        .anon-id-commenter {
+            background: #e9ecef;
+            color: #495057;
+        }
+
+        /* 评论区优化 */
+        .comment-item {
+            padding: 8px 0;
+            border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+        }
+
+        .comment-item:last-child {
+            border-bottom: none;
+        }
+    </style>
 </head>
 
 <body class="app-page">
@@ -43,109 +90,170 @@
                     </ul>
                 </div>
                 <% } else { %>
-                    <img src="/images/mascot.jpg" class="rounded-circle" width="35" height="35"
-                        style="object-fit:cover;">
+                    <span></span>
                     <% } %>
         </div>
     </nav>
 
-    <div class="container" style="margin-top: 80px;">
+    <div class="container py-4">
         <div class="row">
-            <div class="col-md-4 mb-4">
-                <div class="glass-card p-3 sticky-top" style="top: 90px; z-index: 1;">
-                    <h5 class="mb-3">📝 写下回忆</h5>
+            <!-- 左侧发帖区 -->
+            <div class="col-lg-4 col-md-5 mb-4">
+                <div class="glass-card p-4 post-form-card">
+                    <h5 class="mb-3"><i class="fas fa-pen-fancy text-success me-2"></i>写下回忆</h5>
                     <form action="/class/<%= currentClass.id %>/post" method="POST" enctype="multipart/form-data">
                         <div class="mb-3">
-                            <textarea name="content" class="form-control" rows="4" placeholder="今天发生了什么有趣的事..."
-                                required></textarea>
+                            <textarea name="content" class="form-control" rows="5"
+                                placeholder="今天发生了什么有趣的事...&#10;分享给同学们吧！" required></textarea>
                         </div>
                         <div class="mb-3">
-                            <label class="form-label text-muted small">上传照片 (可选)</label>
+                            <label class="form-label text-muted small">
+                                <i class="fas fa-image me-1"></i>上传照片 (可选)
+                            </label>
                             <input type="file" name="image" class="form-control form-control-sm" accept="image/*">
                         </div>
-                        <button type="submit" class="btn btn-success w-100">发布</button>
+                        <button type="submit" class="btn btn-success w-100">
+                            <i class="fas fa-paper-plane me-2"></i>发布
+                        </button>
                     </form>
+
+                    <div class="mt-4 pt-3 border-top">
+                        <small class="text-muted">
+                            <i class="fas fa-info-circle me-1"></i>
+                            评论区采用匿名ID，每个帖子内相同颜色的ID代表同一发言者
+                        </small>
+                    </div>
                 </div>
             </div>
 
-            <div class="col-md-8">
-                <% posts.forEach(post=> { %>
-                    <div class="glass-card mb-4 p-0 overflow-hidden">
-                        <div class="p-3 border-bottom border-light">
-                            <div class="d-flex align-items-center">
-                                <div class="rounded-circle bg-success d-flex align-items-center justify-content-center me-2"
-                                    style="width: 40px; height: 40px; color: white; font-weight: bold;">
-                                    <%= post.author_name ? post.author_name.charAt(0).toUpperCase() : '?' %>
-                                </div>
-                                <div>
-                                    <div class="fw-bold">
-                                        <%= post.author_name || '匿名用户' %>
-                                    </div>
-                                    <small class="text-muted">
-                                        <%= moment(post.created_at).format('YYYY-MM-DD HH:mm') %>
-                                    </small>
-                                </div>
-                            </div>
-                        </div>
-
-                        <div class="p-3">
-                            <p class="card-text mb-3" style="white-space: pre-wrap;">
-                                <%= post.content %>
-                            </p>
-                            <% if(post.image) { %>
-                                <img src="<%= post.image %>" class="img-fluid rounded mb-3 w-100"
-                                    style="max-height: 500px; object-fit: cover;">
-                                <% } %>
-                        </div>
-
-                        <div
-                            class="bg-light bg-opacity-50 p-2 d-flex justify-content-between align-items-center border-top border-light">
-                            <div>
-                                <form action="/post/<%= post.id %>/like" method="POST" class="d-inline">
-                                    <button type="submit" class="btn btn-sm text-danger"><i class="far fa-heart"></i>
-                                        <%= post.likes %>
-                                    </button>
-                                </form>
-                                <span class="text-muted small ms-2"><i class="far fa-comment"></i>
-                                    <%= post.comments.length %>
-                                </span>
-                            </div>
-                            <form action="/post/<%= post.id %>/report" method="POST" class="d-inline">
-                                <button type="submit" class="btn btn-sm text-muted small">⚠️ 举报</button>
-                            </form>
-                        </div>
-
-                        <% if(post.comments.length> 0) { %>
-                            <div class="p-3 bg-white bg-opacity-25 border-top border-light">
-                                <% post.comments.forEach(c=> { %>
-                                    <div class="mb-1 small">
-                                        <span class="fw-bold text-success">
-                                            <%= c.author_name || '同学' %>:
-                                        </span>
-                                        <%= c.content %>
-                                    </div>
-                                    <% }) %>
-                            </div>
-                            <% } %>
-
-                                <div class="p-2 border-top border-light">
-                                    <form action="/post/<%= post.id %>/comment" method="POST"
-                                        class="input-group input-group-sm">
-                                        <input type="text" name="commentContent" class="form-control border-0 bg-light"
-                                            placeholder="评论一句..." required>
-                                        <button class="btn btn-outline-secondary" type="submit">发送</button>
-                                    </form>
-                                </div>
+            <!-- 右侧帖子流 -->
+            <div class="col-lg-8 col-md-7">
+                <% if(posts.length===0) { %>
+                    <div class="glass-card p-5 text-center text-muted">
+                        <i class="fas fa-inbox fa-3x mb-3"></i>
+                        <h5>还没有帖子</h5>
+                        <p>快来写下第一条回忆吧！</p>
                     </div>
-                    <% }) %>
+                    <% } %>
 
-                        <% if(posts.length===0) { %>
-                            <div class="glass-card p-5 text-center text-muted">
-                                <i class="fas fa-inbox fa-3x mb-3"></i>
-                                <h5>还没有帖子</h5>
-                                <p>快来写下第一条回忆吧！</p>
+                        <% posts.forEach(post=> {
+                            // 为这个帖子生成用户ID映射
+                            const userIdMap = {};
+                            let idCounter = 1;
+                            const getAnonId = (userId) => {
+                            if (!userId) return '匿名';
+                            if (!userIdMap[userId]) {
+                            userIdMap[userId] = idCounter++;
+                            }
+                            return '路人' + String.fromCharCode(64 + userIdMap[userId]); // 路人A, 路人B...
+                            };
+                            // 帖子作者固定为"楼主"
+                            const posterUserId = post.user_id;
+                            %>
+                            <div class="glass-card mb-4 p-0 overflow-hidden">
+                                <!-- 帖子头部 -->
+                                <div class="p-3 border-bottom border-light">
+                                    <div class="d-flex align-items-center justify-content-between">
+                                        <div class="d-flex align-items-center">
+                                            <div class="rounded-circle bg-gradient d-flex align-items-center justify-content-center me-2"
+                                                style="width: 42px; height: 42px; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white; font-weight: bold;">
+                                                楼
+                                            </div>
+                                            <div>
+                                                <div class="d-flex align-items-center gap-2">
+                                                    <span class="fw-bold">楼主</span>
+                                                    <span class="anon-id anon-id-poster">
+                                                        <%= post.author_name || '匿名' %>
+                                                    </span>
+                                                </div>
+                                                <small class="text-muted">
+                                                    <%= moment(post.created_at).format('MM-DD HH:mm') %>
+                                                </small>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <!-- 帖子内容 -->
+                                <div class="p-3">
+                                    <p class="card-text mb-0" style="white-space: pre-wrap; line-height: 1.7;">
+                                        <%= post.content %>
+                                    </p>
+                                </div>
+
+                                <% if(post.image) { %>
+                                    <div class="px-3 pb-3">
+                                        <img src="<%= post.image %>" class="img-fluid rounded w-100"
+                                            style="max-height: 500px; object-fit: cover; cursor: pointer;"
+                                            onclick="window.open(this.src)">
+                                    </div>
+                                    <% } %>
+
+                                        <!-- 操作栏 -->
+                                        <div
+                                            class="bg-light bg-opacity-50 px-3 py-2 d-flex justify-content-between align-items-center border-top border-light">
+                                            <div class="d-flex align-items-center gap-3">
+                                                <form action="/post/<%= post.id %>/like" method="POST" class="d-inline">
+                                                    <button type="submit"
+                                                        class="btn btn-sm btn-link text-danger p-0 text-decoration-none">
+                                                        <i class="far fa-heart"></i>
+                                                        <%= post.likes %>
+                                                    </button>
+                                                </form>
+                                                <span class="text-muted small">
+                                                    <i class="far fa-comment"></i>
+                                                    <%= post.comments.length %>
+                                                </span>
+                                            </div>
+                                            <form action="/post/<%= post.id %>/report" method="POST" class="d-inline">
+                                                <button type="submit"
+                                                    class="btn btn-sm btn-link text-muted p-0 text-decoration-none small">
+                                                    <i class="fas fa-flag"></i> 举报
+                                                </button>
+                                            </form>
+                                        </div>
+
+                                        <!-- 评论区 -->
+                                        <% if(post.comments.length> 0) { %>
+                                            <div class="p-3 bg-white bg-opacity-50 border-top border-light">
+                                                <div class="small text-muted mb-2">
+                                                    <i class="fas fa-comments me-1"></i>评论 (<%= post.comments.length %>)
+                                                </div>
+                                                <% post.comments.forEach((c, index)=> {
+                                                    const isOP = c.user_id && c.user_id === posterUserId;
+                                                    const displayId = isOP ? '楼主' : getAnonId(c.user_id);
+                                                    %>
+                                                    <div class="comment-item">
+                                                        <div class="d-flex align-items-start gap-2">
+                                                            <span
+                                                                class="anon-id <%= isOP ? 'anon-id-poster' : 'anon-id-commenter' %>">
+                                                                <%= displayId %>
+                                                            </span>
+                                                            <div class="flex-grow-1">
+                                                                <span class="small">
+                                                                    <%= c.content %>
+                                                                </span>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                    <% }) %>
+                                            </div>
+                                            <% } %>
+
+                                                <!-- 评论输入框 -->
+                                                <div class="p-2 border-top border-light">
+                                                    <form action="/post/<%= post.id %>/comment" method="POST"
+                                                        class="d-flex gap-2">
+                                                        <input type="text" name="commentContent"
+                                                            class="form-control form-control-sm border-0 bg-light"
+                                                            placeholder="写下你的评论..." required>
+                                                        <button class="btn btn-sm btn-success px-3" type="submit">
+                                                            <i class="fas fa-paper-plane"></i>
+                                                        </button>
+                                                    </form>
+                                                </div>
                             </div>
-                            <% } %>
+                            <% }) %>
             </div>
         </div>
     </div>

--- a/views/register.ejs
+++ b/views/register.ejs
@@ -134,22 +134,21 @@
                         <div class="row g-2 mb-3">
                             <div class="col-6">
                                 <div class="form-floating">
-                                    <select class="form-select" id="campus" name="campus" required>
-                                        <option value="">请选择</option>
-                                        <option value="主校区">主校区</option>
-                                        <option value="大旺校区">大旺校区</option>
-                                    </select>
-                                    <label for="campus">校区</label>
-                                </div>
-                            </div>
-                            <div class="col-6">
-                                <div class="form-floating">
-                                    <select class="form-select" id="schoolType" name="schoolType" required>
+                                    <select class="form-select" id="schoolType" name="schoolType" required
+                                        onchange="updateCampusOptions()">
                                         <option value="">请选择</option>
                                         <option value="初中">初中</option>
                                         <option value="高中">高中</option>
                                     </select>
                                     <label for="schoolType">初/高中</label>
+                                </div>
+                            </div>
+                            <div class="col-6">
+                                <div class="form-floating">
+                                    <select class="form-select" id="campus" name="campus" required>
+                                        <option value="">先选初/高中</option>
+                                    </select>
+                                    <label for="campus">校区</label>
                                 </div>
                             </div>
                         </div>
@@ -194,6 +193,32 @@
     </div>
 
     <script>
+        // 根据初/高中选择更新校区选项
+        function updateCampusOptions() {
+            const schoolType = document.getElementById('schoolType').value;
+            const campusSelect = document.getElementById('campus');
+
+            // 清空现有选项
+            campusSelect.innerHTML = '';
+
+            if (!schoolType) {
+                campusSelect.innerHTML = '<option value="">先选初/高中</option>';
+                return;
+            }
+
+            if (schoolType === '高中') {
+                // 高中只有一个校区
+                campusSelect.innerHTML = '<option value="高中部">高中部（主校区）</option>';
+            } else if (schoolType === '初中') {
+                // 初中有两个校区
+                campusSelect.innerHTML = `
+                    <option value="">请选择校区</option>
+                    <option value="信安校区">信安校区</option>
+                    <option value="府城校区">府城校区</option>
+                `;
+            }
+        }
+
         // 密码确认验证
         document.querySelector('form').addEventListener('submit', function (e) {
             const pwd = document.getElementById('password').value;


### PR DESCRIPTION
新功能
- 邀请码注册系统（每人注册后获得3个邀请码）
- 用户登录/注册/退出，Session保持30天
- 管理员面板：生成邀请码、班级管理、举报处理
- 评论区单帖匿名ID（楼主/路人A/B/C）

修复
- 注册页校区选项：高中1个校区，初中2个校区（信安/府城）
- 班级页布局：修复发帖框被顶部导航遮挡
- 图片上传：使用独立目录，部署不覆盖用户文件

部署优化
- 新增 ecosystem.config.js（PM2配置）
- 更新 GitHub Actions：排除uploads目录、生产环境启动
- 上传文件存储到 /var/www/zqzx-uploads/

数据库
- 新增 users, invite_codes, reports 表
- posts/comments 表添加 user_id 字段